### PR TITLE
Added functionality to disable speedtest during benchmarks

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -153,7 +153,14 @@ echo "Memory:" >> $tmpdir/nems-benchmark.log
 echo "---------------------------------" >> $tmpdir/nems-benchmark.log
 
 echo "Internet Speed:" >> $tmpdir/nems-benchmark.log
-/usr/local/share/nems/nems-scripts/speedtest --simple >> $tmpdir/nems-benchmark.log
+disablespeedtest=`/usr/local/bin/nems-info disablespeedtest`
+if [[ $disablespeedtest == 1 ]]; then
+  echo "Ping: N/A ms" >> $tmpdir/nems-benchmark.log
+  echo "Download: N/A Mbit/s" >> $tmpdir/nems-benchmark.log
+  echo "Upload: N/A Mbit/s" >> $tmpdir/nems-benchmark.log
+else
+  /usr/local/share/nems/nems-scripts/speedtest --simple >> $tmpdir/nems-benchmark.log
+fi
 
 echo "---------------------------------" >> $tmpdir/nems-benchmark.log
 

--- a/info.sh
+++ b/info.sh
@@ -227,8 +227,12 @@ elif [[ $COMMAND == "hwid" ]]; then
   fi
 
 elif [[ $COMMAND == "speedtest" ]]; then
-# output json response of detected wifi networks
+# output value of selected speedtest server 
   /usr/local/share/nems/nems-scripts/info2.sh 10 $VARIABLE
+
+elif [[ $COMMAND == "disablespeedtest" ]]; then
+# output value of selected speedtest server 
+  cat /usr/local/share/nems/nems.conf | grep disablespeedtest |  printf '%s' $(cut -n -d '=' -f 2)
 
 elif [[ $COMMAND == "livestatus" ]]; then
 # output json response of livestatus query


### PR DESCRIPTION
Fixed a copy & paste comment typo on line 230 in info.sh

Added the functionality to run "nems-info disablespeedtest" and output the value of the flag from nems.conf

Added a check in benchmark.sh that looks to see if the "disablespedtest" flag in nems.conf is raised. If so, then it outputs "N/A" results for ping, upload, and download. Otherwise, it runs as normal. 